### PR TITLE
Read template section from netlify.toml to load site creation time settings.

### DIFF
--- a/src/automation.js
+++ b/src/automation.js
@@ -65,8 +65,17 @@ function netlifyTomlSettings(files) {
   if (!files['netlify.toml']) { return; }
 
   const config = TOML.parse(files['netlify.toml']);
-  if (config && config.build) {
-    return {cmd: config.build.command, dir: config.build.publish}
+  if (config) {
+    const settings = {};
+    if (config.build) {
+      settings["cmd"] = config.build.command;
+      settings["dir"] = config.build.publish;
+    }
+
+    if (config.template) {
+      settings["template"] = config.template;
+    }
+    return settings;
   }
 }
 

--- a/test/src/automation.spec.js
+++ b/test/src/automation.spec.js
@@ -74,5 +74,11 @@ describe('automation', () => {
         dir: "dist"
       });
     })
+
+    it('should read template from netlify.tml file', () => {
+      expect(settings({'netlify.toml': '[template]\nincoming-hooks = ["Service-1"]'})).toEqual({
+        template: {"incoming-hooks": ["Service-1"]}
+      });
+    })
   });
 });


### PR DESCRIPTION
The template section tells Netlify about settings to read about only when sites are created. After that, those settings are managed in the UI or build sections. That way, we avoid inconsistencies between sites and config files.

/cc @biilmann

Signed-off-by: David Calavera <david.calavera@gmail.com>